### PR TITLE
Disable UICollectionView Prefetching function in iOS10, in order to f…

### DIFF
--- a/NoChat/Source/ChatViewController.swift
+++ b/NoChat/Source/ChatViewController.swift
@@ -126,6 +126,9 @@ open class ChatViewController: UIViewController {
         collectionView.scrollsToTop = false
         collectionView.dataSource = self
         collectionView.delegate = self
+        if #available(iOS 10, *) {
+            collectionView.isPrefetchingEnabled = false
+        }
         collectionView.transform = inverted ? CGAffineTransform(a: 1, b: 0, c: 0, d: -1, tx: 0, ty: 0) : CGAffineTransform.identity
         chatItemsContainer.addSubview(self.collectionView)
         


### PR DESCRIPTION
I figured out that the new UICollectionView Prefetching function will make the library crash when scrolling the Messages View.

Therefore, I disable it to fix the crash.